### PR TITLE
Added contract specification for etherscan chunk.

### DIFF
--- a/packages/hardhat/scripts/deploy.js
+++ b/packages/hardhat/scripts/deploy.js
@@ -58,6 +58,7 @@ const main = async () => {
   console.log(chalk.blue('verifying on etherscan'))
   await run("verify:verify", {
     address: yourContract.address,
+    // contract: "contracts/Example.sol:ExampleContract" // If you are inheriting from multiple contracts in yourContract.sol, you can specify which to verify
     // constructorArguments: args // If your contract has constructor arguments, you can pass them as an array
   })
   */


### PR DESCRIPTION
As discussed in Telegram, this could be useful to someone if they are inheriting from OpenZeppelin or other libraries.